### PR TITLE
DM-33918: Create code repository for prompt processing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,3 +10,4 @@ The design for the framework is described in `DMTN-219`_.
 .. _DMTN-219: https://dmtn-219.lsst.io/
 
 At present, the package does not conform exactly to the layout or conventions of LSST stack packages.
+In particular, the Python code is currently located in ``src/``, and does not use the ``lsst`` namespace.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 110
 max-doc-length = 79
-ignore = E133, E226, E228, W503
+ignore = E133, E226, E228, W503, W505
 exclude =
   bin,
   doc/conf.py,
@@ -11,4 +11,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 W503
+flake8-ignore = E133 E226 E228 W503 W505

--- a/src/activator/.dockerignore
+++ b/src/activator/.dockerignore
@@ -1,0 +1,7 @@
+Dockerfile
+README.md
+*.pyc
+*.pyo
+*.pyd
+__pycache__
+.pytest_cache

--- a/src/activator/.gcloudignore
+++ b/src/activator/.gcloudignore
@@ -1,0 +1,19 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Python pycache:
+__pycache__/
+# Ignored by the build system
+/setup.cfg

--- a/src/activator/Dockerfile
+++ b/src/activator/Dockerfile
@@ -1,0 +1,14 @@
+FROM us-central1-docker.pkg.dev/prompt-proto/prompt/prompt-proto-base:latest
+ENV PYTHONUNBUFFERED True
+ENV APP_HOME /app
+ARG RUBIN_INSTRUMENT
+ARG PUBSUB_VERIFICATION_TOKEN
+ARG PORT
+ARG CALIB_REPO
+ARG IMAGE_BUCKET
+ARG IMAGE_TIMEOUT
+WORKDIR $APP_HOME
+COPY . ./
+CMD source /opt/lsst/software/stack/loadLSST.bash \
+    && setup lsst_distrib \
+    && exec gunicorn --bind :$PORT --workers 1 --threads 1 --timeout 0 activator:app

--- a/src/activator/activator.py
+++ b/src/activator/activator.py
@@ -1,0 +1,174 @@
+import base64
+import json
+import logging
+import os
+import re
+import time
+from typing import Optional, Tuple
+
+from flask import Flask, request
+from google.cloud import pubsub_v1, storage
+
+from middleware_interface import MiddlewareInterface
+from visit import Visit
+
+PROJECT_ID = "prompt-proto"
+
+verification_token = os.environ["PUBSUB_VERIFICATION_TOKEN"]
+config_instrument = os.environ["RUBIN_INSTRUMENT"]
+calib_repo = os.environ["CALIB_REPO"]
+image_bucket = os.environ["IMAGE_BUCKET"]
+oid_regexp = re.compile(r"(.*?)/(\d+)/(.*?)/(\d+)/\1-\3-\4-.*?-.*?-\2\.f")
+timeout = os.environ.get("IMAGE_TIMEOUT", 50)
+
+logging.basicConfig(
+    # Use JSON format compatible with Google Cloud Logging
+    format=(
+        '{{"severity":"{levelname}", "labels":{{"instrument":"'
+        + config_instrument
+        + '"}}, "message":{message!r}}}'
+    ),
+    style="{",
+)
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+app = Flask(__name__)
+
+subscriber = pubsub_v1.SubscriberClient()
+topic_path = subscriber.topic_path(
+    PROJECT_ID,
+    f"{config_instrument}-image",
+)
+subscription = None
+
+storage_client = storage.Client()
+
+# Initialize middleware interface, including copying standard calibrations
+mwi = MiddlewareInterface(calib_repo, image_bucket, config_instrument)
+
+
+def check_for_snap(
+    instrument: str, group: int, snap: int, detector: int
+) -> Optional[str]:
+    prefix = f"{instrument}/{detector}/{group}/{snap}/{instrument}-{group}-{snap}-"
+    logger.debug(f"Checking for '{prefix}'")
+    blobs = list(storage_client.list_blobs(image_bucket, prefix=prefix))
+    if not blobs:
+        return None
+    elif len(blobs) > 1:
+        logger.error(
+            f"Multiple files detected for a single group/snap/detector: '{prefix}'"
+        )
+    return blobs[0]
+
+
+@app.route("/next-visit", methods=["POST"])
+def next_visit_handler() -> Tuple[str, int]:
+    if request.args.get("token", "") != verification_token:
+        return "Invalid request", 400
+    subscription = subscriber.create_subscription(
+        topic=topic_path,
+        ack_deadline_seconds=60,
+    )
+    logger.debug(f"Created subscription '{subscription.name}'")
+    try:
+        envelope = request.get_json()
+        if not envelope:
+            msg = "no Pub/Sub message received"
+            logging.warn(f"error: '{msg}'")
+            return f"Bad Request: {msg}", 400
+
+        if not isinstance(envelope, dict) or "message" not in envelope:
+            msg = "invalid Pub/Sub message format"
+            logging.warn(f"error: '{msg}'")
+            return f"Bad Request: {msg}", 400
+
+        payload = base64.b64decode(envelope["message"]["data"])
+        data = json.loads(payload)
+        expected_visit = Visit(**data)
+        assert expected_visit.instrument == config_instrument
+        snap_set = set()
+
+        # Copy calibrations for this detector/visit
+        mwi.prep_butler(expected_visit)
+
+        # Check to see if any snaps have already arrived
+        for snap in range(expected_visit.snaps):
+            oid = check_for_snap(
+                expected_visit.instrument,
+                expected_visit.group,
+                snap,
+                expected_visit.detector,
+            )
+            if oid:
+                mwi.ingest_image(oid)
+                snap_set.add(snap)
+
+        logger.debug(
+            "Waiting for snaps from group"
+            f" '{expected_visit.group}' detector {expected_visit.detector}"
+        )
+        start = time.time()
+        while len(snap_set) < expected_visit.snaps:
+            response = subscriber.pull(
+                subscription=subscription.name,
+                max_messages=189 + 8 + 8,
+                timeout=timeout,
+            )
+            end = time.time()
+            if len(response.received_messages) == 0:
+                if end - start < timeout:
+                    logger.debug(
+                        f"Empty pull after {end - start}"
+                        f" for '{expected_visit.group}'"
+                    )
+                    continue
+                logger.warning(
+                    "Timed out waiting for image in"
+                    f" '{expected_visit.group}' after receiving snaps {snap_set}"
+                )
+                break
+
+            ack_list = []
+            for received in response.received_messages:
+                ack_list.append(received.ack_id)
+                oid = received.message.attributes["objectId"]
+                m = re.match(oid_regexp, oid)
+                if m:
+                    instrument, detector, group, snap = m.groups()
+                    logger.debug(m.groups())
+                    if (
+                        instrument == expected_visit.instrument
+                        and int(detector) == int(expected_visit.detector)
+                        and group == str(expected_visit.group)
+                        and int(snap) < int(expected_visit.snaps)
+                    ):
+                        # Ingest the snap
+                        mwi.ingest_image(oid)
+                        snap_set.add(snap)
+                else:
+                    logger.error(f"Failed to match object id '{oid}'")
+            subscriber.acknowledge(subscription=subscription.name, ack_ids=ack_list)
+
+        # Got all the snaps; run the pipeline
+        mwi.run_pipeline(expected_visit, snap_set)
+        return "Pipeline executed", 200
+    finally:
+        subscriber.delete_subscription(subscription=subscription.name)
+
+
+@app.errorhandler(500)
+def server_error(e) -> Tuple[str, int]:
+    logger.exception("An error occurred during a request.")
+    return (
+        f"""
+    An internal error occurred: <pre>{e}</pre>
+    See logs for full stacktrace.
+    """,
+        500,
+    )
+
+
+if __name__ == "__main__":
+    with subscriber:
+        app.run(host="127.0.0.1", port=8080, debug=True)

--- a/src/activator/middleware_interface.py
+++ b/src/activator/middleware_interface.py
@@ -1,0 +1,163 @@
+import logging
+import os
+import shutil
+
+from astropy.time import Time
+from lsst.daf.butler import Butler
+
+from visit import Visit
+
+PIPELINE_MAP = dict(
+    BIAS="bias.yaml",
+    DARK="dark.yaml",
+    FLAT="flat.yaml",
+)
+
+_log = logging.getLogger(__name__)
+_log.setLevel(logging.DEBUG)
+
+
+class MiddlewareInterface:
+    def __init__(self, input_repo: str, image_bucket: str, instrument: str):
+
+        # self.src = Butler(input_repo, writeable=False)
+        _log.info(f"Butler({input_repo}, writeable=False)")
+        self.image_bucket = image_bucket
+        self.instrument = instrument
+
+        self.repo = "/tmp/butler-{os.getpid()}"
+        if not os.path.exists(self.repo):
+            _log.info(f"Making local Butler {self.repo}")
+            Butler.makeRepo(self.repo)
+        else:
+            _log.info(f"Local Butler {self.repo} exists")
+        self.dest = Butler(self.repo, writeable=True)
+
+        # self.r = self.src.registry
+        self.calibration_collection = f"{instrument}/calib"
+        refcat_collection = "refcats/DM-28636"
+
+        export_collections = set()
+        export_collections.add(self.calibration_collection)
+        # calib_collections = list(
+        #     self.r.queryCollections(
+        #         self.calibration_collection,
+        #         flattenChains=True,
+        #         includeChains=True,
+        #         collectionTypes={CollectionType.CALIBRATION, CollectionType.CHAINED},
+        #     )
+        # )
+        # for collection in calib_collections:
+        #     export_collections.add(collection)
+        export_collections.add(refcat_collection)
+
+        # for dataset in self.r.queryDatasets(
+        #     "gaia_dr2_20200414",
+        #     where=f"htm7 IN ({htm7})",
+        #     collections=refcat_collection,
+        # ):
+        #     export_datasets.add(dataset)
+        # for dataset in self.r.queryDatasets(
+        #     "ps1_pv3_3pi_20170110",
+        #     where=f"htm7 IN ({htm7})",
+        #     collections=refcat_collection,
+        # ):
+        #     export_datasets.add(dataset)
+
+        prep_dir = "/tmp/butler-export"
+        os.makedirs(prep_dir)
+        _log.debug(f"Exporting to {prep_dir}")
+        # with self.src.export(directory=prep_dir, format="yaml", transfer="copy") as e:
+        #     for collection in export_collections:
+        #         e.saveCollection(collection)
+        #     e.saveDatasets(export_datasets)
+        _log.debug(f"Importing from {prep_dir}")
+        # self.dest.import_(directory=prep_dir, format="yaml", transfer="hardlink")
+        shutil.rmtree(prep_dir, ignore_errors=True)
+
+        # self.calib_types = [
+        #     dataset_type
+        #     for dataset_type in self.src.registry.queryDatasetTypes(...)
+        #     if dataset_type.isCalibration()
+        # ]
+        self.calib_types = ["bias", "dark", "defects", "flat", "fringe", ]
+
+    def prep_butler(self, visit: Visit) -> None:
+        _log.info(f"Preparing Butler for visit '{visit}'")
+        visit_info = visit.__dict__
+        for calib_type in self.calib_types:
+            _log.debug(f"Finding {calib_type} datasets dataId={visit_info}"
+                       f" collections={self.calibration_collection}"
+                       f" timespan={Time.now()}")
+            # dataset = self.r.findDataset(
+            #     calib_type,
+            #     dataId=visit_info,
+            #     collections=self.calibration_collection,
+            #     timespan=Timespan(Time.now(), Time.now()),
+            # )
+            # if dataset is not None:
+            #     export_datasets.add(dataset)
+        # Optimization: look for datasets in destination repo to avoid copy.
+
+        for calib_type in self.calib_types:
+            _log.debug(f"Finding {calib_type} associations")
+            # for association in r.queryDatasetAssociations(
+            #     calib_type,
+            #     collections=self.calibration_collection,
+            #     collectionTypes=[CollectionType.CALIBRATION],
+            #     flattenChains=True,
+            # ):
+            #     if filter_calibs(association.ref, visit_info):
+            #         export_collections.add(association.ref.run)
+
+        visit_dir = f"/tmp/visit-{visit.group}-export"
+        _log.debug(f"Exporting to {visit_dir}")
+        os.makedirs(visit_dir)
+        # with self.src.export(directory=visit_dir, format="yaml", transfer="copy") as e:
+        #     for collection in export_collections:
+        #         e.saveCollection(collection)
+        #     e.saveDatasets(export_datasets)
+        _log.debug(f"Importing from {visit_dir}")
+        # self.dest.import_(directory=visit_dir, format="yaml", transfer="hardlink")
+        shutil.rmtree(visit_dir, ignore_errors=True)
+
+    def ingest_image(self, oid: str) -> None:
+        _log.info(f"Ingesting image '{oid}'")
+        run = f"{self.instrument}/raw/all"
+        cmd = [
+            "butler",
+            "ingest-raws",
+            "-t",
+            "copy",
+            "--output_run",
+            run,
+            self.repo,
+            f"gs://{self.image_bucket}/{oid}",
+        ]
+        _log.debug(str(cmd))
+        # subprocess.run(cmd, check=True)
+
+    def run_pipeline(self, visit: Visit, snaps) -> None:
+        pipeline = PIPELINE_MAP[visit.kind]
+        _log.info(f"Running pipeline {pipeline} on visit '{visit}', snaps {snaps}")
+        cmd = [
+            "echo",
+            "pipetask",
+            "run",
+            "-b",
+            self.repo,
+            "-p",
+            pipeline,
+            "-i",
+            f"{self.instrument}/raw/all",
+        ]
+        _log.debug(str(cmd))
+        # subprocess.run(cmd, check=True)
+
+
+def filter_calibs(dataset_ref, visit_info):
+    for dimension in ("instrument", "detector", "physical_filter"):
+        if dimension in dataset_ref.dataId:
+            if dataset_ref.dataId[dimension] != visit_info[dimension]:
+                return False
+    return True

--- a/src/activator/visit.py
+++ b/src/activator/visit.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Visit:
+    instrument: str
+    detector: int
+    group: str
+    snaps: int
+    filter: str
+    ra: float
+    dec: float
+    kind: str

--- a/src/base/Dockerfile
+++ b/src/base/Dockerfile
@@ -1,0 +1,9 @@
+FROM lsstsqre/centos:w_latest
+ENV PYTHONUNBUFFERED True
+RUN source /opt/lsst/software/stack/loadLSST.bash \
+    && mamba install -y \
+        flask \
+        gunicorn \
+        google-cloud-pubsub \
+        google-cloud-sdk \
+        google-cloud-storage

--- a/src/playbook.rst
+++ b/src/playbook.rst
@@ -1,0 +1,145 @@
+#########################################################
+Playbook for the Prompt Processing Proposal and Prototype
+#########################################################
+
+Containers
+==========
+
+The prototype consists of two containers.
+The first is a base container with the Science Pipelines "stack" code and Google Cloud Platform utilities.
+The second is a service container made from the base that has the Prompt Processing prototype service code.
+
+To build the base container using Google Cloud Build:
+
+.. code-block:: sh
+
+   cd base
+   gcloud builds submit --tag us-central1-docker.pkg.dev/prompt-proto/prompt/prompt-proto-base
+
+To build the service container:
+
+.. code-block:: sh
+
+   cd activator
+   gcloud builds submit --tag us-central1-docker.pkg.dev/prompt-proto/prompt/prompt-proto-service
+
+These commands publish to Google Artifact Registry.
+
+You will need to authenticate to Google Cloud first using :command:`gcloud auth login`.
+
+.. note::
+
+   The ``PYTHONUNBUFFERED`` environment variable defined in the Dockerfiles for the containers ensures that container logs are emitted in real-time.
+
+
+Pub/Sub Topics
+==============
+
+One Google Pub/Sub topic is used for ``nextVisit`` events.
+Additional topics are used for images from each instrument, where the instrument is one of ``LSSTCam``, ``LSSTComCam``, ``LATISS``, or ``DECam``.
+
+To create the topic, in the Google Cloud Console for the ``prompt-proto`` project:
+
+* Choose "Pub/Sub"
+* Choose "Create Topic"
+* Set "Topic ID" to ``nextVisit`` or ``{instrument}-image``, replacing ``{instrument}`` with the name from the list above.
+
+The single ``nextVisit`` topic is used for multiple messages per visit, one per detector.
+It is also expected that it can be used with multiple instruments, with filtering on the subscription distinguishing between them.
+Using a single topic this way could simplify the translator from SAL/DDS.
+On the other hand, using multiple topics is also simple to do.
+
+
+Buckets
+=======
+
+A single bucket named ``rubin-prompt-proto-main`` has been created to hold incoming raw images.
+
+An additional bucket will be needed eventually to hold a Butler repo containing calibration datasets and templates.
+
+The raw image bucket has had notifications configured for it; these publish to a Google Pub/Sub topic as mentioned in the previous section.
+To configure these notifications, in a shell:
+
+.. code-block:: sh
+
+   gsutil notification create \
+       -t project/prompt-proto/topics/{instrument}-image \
+       -f json \
+       -e OBJECT_FINALIZE \
+       -p {instrument}/ \
+       gs://rubin-prompt-proto-main
+
+This creates a notification on the given topic using JSON format when an object has been finalized (transfer of it has completed).
+Notifications are only sent on this topic for objects with the instrument name as a prefix.
+
+Prototype Service
+=================
+
+The service can be controlled by Google Cloud Run, which will automatically trigger instances based on ``nextVisit`` messages and can autoscale the number of them depending on load.
+Each time the service container is updated, a new revision of the service should be edited and deployed.
+(Continuous deployment has not yet been set up.)
+
+To create or edit the Cloud Run service in the Google Cloud Console:
+
+* Choose "Create Service" or "Edit & Deploy New Revision"
+* Select the container image URL from "Artifact Registry > prompt-proto-service"
+* In the Variables & Secrets tab, set the following required parameters:
+
+  * RUBIN_INSTRUMENT: name of instrument
+  * PUBSUB_VERIFICATION_TOKEN: choose an arbitrary string matching the Pub/Sub endpoint URL below
+  * IMAGE_BUCKET: bucket containing raw images (``rubin-prompt-proto-main``)
+  * CALIB_REPO: repo containing calibrations (and templates); only used for log messages at present
+
+* There is also one optional parameter:
+
+  * IMAGE_TIMEOUT: timeout in seconds to wait for raw image, default 50 sec.
+
+* One variable is set by Cloud Run and should not be overridden:
+
+  * PORT
+
+* Set the "Request timeout" to 600 seconds (if a worker has not responded by then, it will be killed).
+* Set the "Maximum requests per container" to 1.
+* Under "Autoscaling", the minimum number should be set to 0 to save money while debugging, but it would be a multiple of the number of detectors in production.
+  The maximum number depends on how many simultaneous visits could be in process.
+
+The Cloud Run service URL is given at the top of the service details page.
+Copy it for use in the Pub/Sub subscription.
+
+One subscription needs to be created (once) for the ``nextVisit`` topic.
+It accepts messages and gateways them to Cloud Run.
+
+* Choose "Pub/Sub"
+* Choose "Subscriptions"
+* Choose "Create Subscription"
+* Set "Subscription ID" to "nextVisit-sub"
+* Select the ``projects/prompt-proto/topics/nextVisit`` topic
+* Set "Delivery type" to "Push"
+* Set the "Endpoint URL" to the service URL from Cloud Run, with ``?token={PUBSUB_VERIFICATION_TOKEN}`` appended to it.
+  As mentioned, the string ``{PUBSUB_VERIFICATION_TOKEN}`` should be replaced by an arbitrary string matching the variable set above.
+* Enable authentication using a service account that has Artifact Registry Reader, Cloud Run Invoker, Pub/Sub Editor, Pub/Sub Subscriber, and Storage Object Viewer roles
+* Set "Message retention duration" to 10 minutes
+* Do not "Retain acknowledged messages", and do not expire the subscription
+* Set the acknowledgement deadline to 600 seconds
+* Set the "Retry policy" to "Retry immediately"
+
+
+tester
+======
+
+``tester/upload.py`` is a script that simulates the CCS image writer.
+It takes a JSON token in ``./prompt-proto-upload.json``.
+Command line arguments are the instrument name (LSSTCam, LSSTComCam, LATISS, DECam) and the number of groups of images to send.
+
+Sample command line:
+
+.. code-block:: sh
+
+   python upload.py LSSTComCam 3
+
+It sends ``next_visit`` events for each detector via Google Pub/Sub on the ``nextVisit`` topic.
+It then uploads a batch of files representing the snaps of the visit to the ``rubin-prompt-proto-main`` GCS bucket.
+LSSTCam and LSSTComCam are currently hard-coded at two snaps per group.
+The current data uploaded is just a tiny string.
+
+Eventually a set of parallel processes running on multiple nodes will be needed to upload the images sufficiently rapidly.

--- a/src/tester/upload.py
+++ b/src/tester/upload.py
@@ -81,7 +81,11 @@ def main():
     )
     storage_client = storage.Client(PROJECT_ID, credentials=credentials)
     bucket = storage_client.bucket("rubin-prompt-proto-main")
-    publisher = pubsub_v1.PublisherClient(credentials=credentials)
+    batch_settings = pubsub_v1.types.BatchSettings(
+        max_messages=INSTRUMENTS[instrument].n_detectors,
+    )
+    publisher = pubsub_v1.PublisherClient(credentials=credentials,
+                                          batch_settings=batch_settings)
 
     blobs = storage_client.list_blobs(
         "rubin-prompt-proto-main",

--- a/src/tester/upload.py
+++ b/src/tester/upload.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+from google.cloud import pubsub_v1, storage
+from google.oauth2 import service_account
+import json
+import logging
+import random
+import sys
+import time
+from visit import Visit
+
+
+@dataclass
+class Instrument:
+    n_snaps: int
+    n_detectors: int
+
+
+INSTRUMENTS = {
+    "LSSTCam": Instrument(2, 189 + 8 + 8),
+    "LSSTComCam": Instrument(2, 9),
+    "LATISS": Instrument(1, 1),
+    "DECam": Instrument(1, 62),
+}
+EXPOSURE_INTERVAL = 18
+SLEW_INTERVAL = 2
+FILTER_LIST = "ugrizy"
+PUBSUB_TOKEN = "abc123"
+KINDS = ("BIAS", "DARK", "FLAT")
+
+PROJECT_ID = "prompt-proto"
+
+
+logging.basicConfig(
+    format="{levelname} {asctime} {name} - {message}",
+    style="{",
+    level=logging.DEBUG,
+)
+
+
+def process_group(publisher, bucket, instrument, group, filter, kind):
+    n_snaps = INSTRUMENTS[instrument].n_snaps
+    send_next_visit(publisher, instrument, group, n_snaps, filter, kind)
+    for snap in range(n_snaps):
+        logging.info(f"Taking group {group} snap {snap}")
+        time.sleep(EXPOSURE_INTERVAL)
+        for detector in range(INSTRUMENTS[instrument].n_detectors):
+            logging.info(f"Uploading {group} {snap} {filter} {detector}")
+            exposure_id = (group // 100000) * 100000
+            exposure_id += (group % 100000) * INSTRUMENTS[instrument].n_snaps
+            exposure_id += snap
+            fname = (
+                f"{instrument}/{detector}/{group}/{snap}"
+                f"/{instrument}-{group}-{snap}"
+                f"-{exposure_id}-{filter}-{detector}.fz"
+            )
+            bucket.blob(fname).upload_from_string("Test")
+            logging.info(f"Uploaded {group} {snap} {filter} {detector}")
+
+
+def send_next_visit(publisher, instrument, group, snaps, filter, kind):
+    topic_path = publisher.topic_path(PROJECT_ID, "nextVisit")
+    ra = random.uniform(0.0, 360.0)
+    dec = random.uniform(-90.0, 90.0)
+    for detector in range(INSTRUMENTS[instrument].n_detectors):
+        visit = Visit(instrument, detector, group, snaps, filter, ra, dec, kind)
+        data = json.dumps(visit.__dict__).encode("utf-8")
+        publisher.publish(topic_path, data=data)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} INSTRUMENT N_GROUPS")
+        sys.exit(1)
+    instrument = sys.argv[1]
+    n_groups = int(sys.argv[2])
+
+    date = time.strftime("%Y%m%d")
+
+    credentials = service_account.Credentials.from_service_account_file(
+        "./prompt-proto-upload.json"
+    )
+    storage_client = storage.Client(PROJECT_ID, credentials=credentials)
+    bucket = storage_client.bucket("rubin-prompt-proto-main")
+    publisher = pubsub_v1.PublisherClient(credentials=credentials)
+
+    blobs = storage_client.list_blobs(
+        "rubin-prompt-proto-main",
+        prefix=f"{instrument}/0/{date}",
+        delimiter="/",
+    )
+    for blob in blobs:
+        pass
+    prefixes = [int(prefix.split("/")[2]) for prefix in blobs.prefixes]
+    if len(prefixes) == 0:
+        last_group = int(date) * 100000
+    else:
+        last_group = max(prefixes) + random.randrange(10, 19)
+    logging.info(f"Last group {last_group}")
+
+    for i in range(n_groups):
+        kind = KINDS[i % len(KINDS)]
+        group = last_group + i + 1
+        filter = FILTER_LIST[random.randrange(0, len(FILTER_LIST))]
+        process_group(publisher, bucket, instrument, group, filter, kind)
+        logging.info("Slewing to next group")
+        time.sleep(SLEW_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tester/visit.py
+++ b/src/tester/visit.py
@@ -1,0 +1,1 @@
+../activator/visit.py

--- a/ups/prompt-prototype.table
+++ b/ups/prompt-prototype.table
@@ -4,5 +4,6 @@
 #   the "base" package.
 setupRequired(base)
 setupRequired(sconsUtils)
+setupRequired(daf_butler)    # Used by middleware_interface module.
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
This PR adds in the code removed from lsst-dm/dmtn-219#2. The code has been cleaned up to pass `flake8`, but no attempt has been made to further reconcile it with LSST conventions such as namespacing.